### PR TITLE
Fix dataset slicing for cube loader

### DIFF
--- a/bracket_net/data/cube.py
+++ b/bracket_net/data/cube.py
@@ -281,10 +281,11 @@ def get_moves(batch):
 
 
 def BaseLoader(collate_fn, val_test_rate=0.1, batch_size=32, size=None):
-    data = R222ShortestAll(size=size)
+    data_set = R222ShortestAll(size=size)
+    # Ignore the first entry since it corresponds to the solved state
+    data = data_set.data[1:]
 
     train_data_start = 0
-    # train_data_start = 1 # ignore the first data because it is solved state
     train_data_end = int(len(data)*(1 - 2*val_test_rate))
     train_dataloader = IterableWrapper(data[train_data_start:train_data_end])
     train_dataloader = train_dataloader.batch(batch_size=batch_size, drop_last=True)


### PR DESCRIPTION
## Summary
- avoid invalid empty move string by skipping the solved state entry when loading cube data

## Testing
- `test/unittest.sh` *(fails: ModuleNotFoundError: No module named 'torch')*
- `test/integration.sh` *(fails: ModuleNotFoundError: No module named 'hydra')*